### PR TITLE
[FIX] Corrected typo in unblacklist executor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ drove executor unblacklist executor-id [executor-id ...]
 
 ###### Positional Arguments
 
-`executor-id` - List of executor ids to be bought in to the rotation. At least one is mandatory.
+`executor-id` - List of executor ids to be brought in to the rotation. At least one is mandatory.
 
 ### cluster
 ---

--- a/README.md
+++ b/README.md
@@ -357,12 +357,12 @@ drove executor blacklist executor-id [executor-id ...]
 Bring blacklisted executors back into rotation.
 
 ```shell
-drove executor blacklist executor-id [executor-id ...]
+drove executor unblacklist executor-id [executor-id ...]
 ```
 
 ###### Positional Arguments
 
-`executor-id` - List of executor ids to be blacklisted. At least one is mandatory.
+`executor-id` - List of executor ids to be bought in to the rotation. At least one is mandatory.
 
 ### cluster
 ---


### PR DESCRIPTION
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L360-R365): Updated the command from `drove executor blacklist executor-id [executor-id ...]` to `drove executor unblacklist executor-id [executor-id ...]` to accurately reflect the intended functionality.