### PR TITLE
Added plugin identification

### DIFF
--- a/drovecli.py
+++ b/drovecli.py
@@ -32,7 +32,6 @@ class DroveCli:
             plugin = self.plugins.get(args.plugin)
             if plugin and plugin.needs_client():
                 droveclient.build_drove_client(plugin.drove_client, args)
-                print("Created client for plugin: " + args.plugin)
         args.func(args)
     
     def show_help(self, options: SimpleNamespace) -> None:

--- a/drovecli.py
+++ b/drovecli.py
@@ -8,15 +8,15 @@ from types import SimpleNamespace
 class DroveCli:
     def __init__(self, parser: argparse.ArgumentParser):
         self.parser = parser
-        self.plugins: list = []
+        self.plugins: dict[str, DrovePlugin] = {}
         self.debug = False
-        subparsers = parser.add_subparsers(help="Available plugins")
+        subparsers = parser.add_subparsers(help="Available plugins", dest="plugin")
         drove_client = droveclient.DroveClient()
         for plugin_class in DrovePlugin.plugins:
             plugin = plugin_class()
             # print("Loading plugin: " + str(plugin))
             plugin.populate_options(drove_client=drove_client, subparser=subparsers)
-            self.plugins.append(plugin)
+            self.plugins[plugin.name()] = plugin
         parser.set_defaults(func=self.show_help)
         
         
@@ -25,7 +25,14 @@ class DroveCli:
         self.debug = args.debug
 
         # Load plugins
-        
+        if args.debug:
+            print("Selected plugin: " + args.plugin)
+
+        if args.plugin:
+            plugin = self.plugins.get(args.plugin)
+            if plugin and plugin.needs_client():
+                droveclient.build_drove_client(plugin.drove_client, args)
+                print("Created client for plugin: " + args.plugin)
         args.func(args)
     
     def show_help(self, options: SimpleNamespace) -> None:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -18,18 +18,16 @@ class DrovePlugin:
         self.drove_client: droveclient.DroveClient = None
         self.parser: argparse.ArgumentParser = None
 
+    def name(self) -> str:
+        raise NotImplementedError("Looks like plugin did not implement name() method")
+
     def needs_client(self) -> bool:
         return True
 
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
         self.drove_client = drove_client
-        subparser.set_defaults(func=self.run_plugin)
+        subparser.set_defaults(func=self.process)
         self.parser = subparser
-
-    def run_plugin(self, options: SimpleNamespace):
-        if self.needs_client():
-            droveclient.build_drove_client(self.drove_client, options)
-        self.process(options)
 
     def process(self, options: SimpleNamespace):
         self.parser.print_help()

--- a/plugins/appinstances.py
+++ b/plugins/appinstances.py
@@ -12,8 +12,11 @@ class Applications(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
 
+    def name(self) -> str:
+        return "appinstances"
+
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("appinstances", help="Drove application instance related commands")
+        parser = subparser.add_parser(self.name(), help="Drove application instance related commands")
 
         commands = parser.add_subparsers(help="Available commands for application management")
 

--- a/plugins/applications.py
+++ b/plugins/applications.py
@@ -13,8 +13,11 @@ class Applications(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
 
+    def name(self) -> str:
+        return "apps"
+
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("apps", help="Drove application related commands")
+        parser = subparser.add_parser(self.name(), help="Drove application related commands")
 
         commands = parser.add_subparsers(help="Available commands for application management")
 

--- a/plugins/cluster.py
+++ b/plugins/cluster.py
@@ -9,11 +9,14 @@ import time
 from types import SimpleNamespace
 
 class Cluster(plugins.DrovePlugin):
+    def name(self):
+        return "cluster"
+
     def __init__(self) -> None:
         pass
 
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("cluster", help="Drove cluster related commands")
+        parser = subparser.add_parser(self.name(), help="Drove cluster related commands")
 
         commands = parser.add_subparsers(help="Available commands for cluster management")
 

--- a/plugins/config.py
+++ b/plugins/config.py
@@ -85,11 +85,14 @@ class Config(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
 
+    def name(self) -> str:
+        return "config"
+
     def needs_client(self) -> bool:
         return False
 
     def populate_options(self, drove_client, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("config", help="Manage drove cluster configurations")
+        parser = subparser.add_parser(self.name(), help="Manage drove cluster configurations")
         commands = parser.add_subparsers(help="Available config commands")
 
         # get-clusters: List all available clusters

--- a/plugins/describe.py
+++ b/plugins/describe.py
@@ -33,8 +33,11 @@ class Describe(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
 
+    def name(self) -> str:
+        return "describe"
+
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("describe", help="Show detailed information about a resource")
+        parser = subparser.add_parser(self.name(), help="Show detailed information about a resource")
         commands = parser.add_subparsers(help="Available describe commands")
 
         # describe executor

--- a/plugins/executors.py
+++ b/plugins/executors.py
@@ -10,9 +10,11 @@ from urllib.parse import urlencode
 class Executors(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
+    def name(self) -> str:
+        return "executor"
 
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("executor", help="Drove cluster executor related commands")
+        parser = subparser.add_parser(self.name(), help="Drove cluster executor related commands")
         
         commands = parser.add_subparsers(help="Available commands for cluster executor management")
 

--- a/plugins/localserviceinstances.py
+++ b/plugins/localserviceinstances.py
@@ -12,8 +12,11 @@ class LocalServices(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
 
+    def name(self) -> str:
+        return "lsinstances"
+
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("lsinstances", help="Drove local service instance related commands")
+        parser = subparser.add_parser(self.name(), help="Drove local service instance related commands")
 
         commands = parser.add_subparsers(help="Available commands for local service management")
 

--- a/plugins/localservices.py
+++ b/plugins/localservices.py
@@ -13,8 +13,11 @@ class LocalServices(plugins.DrovePlugin):
     def __init__(self) -> None:
         super().__init__()
 
+    def name(self) -> str:
+        return "localservices"
+
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("localservices", help="Drove local service related commands")
+        parser = subparser.add_parser(self.name(), help="Drove local service related commands")
 
         commands = parser.add_subparsers(help="Available commands for local services management")
 

--- a/plugins/tasks.py
+++ b/plugins/tasks.py
@@ -12,8 +12,11 @@ class Tasks(plugins.DrovePlugin):
     def __init__(self) -> None:
         pass
 
+    def name(self) -> str:
+        return "tasks"
+
     def populate_options(self, drove_client: droveclient.DroveClient, subparser: argparse.ArgumentParser):
-        parser = subparser.add_parser("tasks", help="Drove task related commands")
+        parser = subparser.add_parser(self.name(), help="Drove task related commands")
 
         commands = parser.add_subparsers(help="Available commands for task management")
 


### PR DESCRIPTION
## Changes
    - Added `name()` method in plugin interface
    - A map not maintains all plugins by name
    - If plugin needs drove client, it is initialized

## Test Output:

### command needs endpoint but not provided:
```
$ ./drove.py cluster summary 
Drove CLI error: Error: provide config file or required command line params for drove connectivity
```
### command needs endpoint and provided:
```
$ ./drove.py -e http://localhost:10000 cluster summary 
Created client for plugin: cluster
State                         NORMAL
Leader Controller             localhost:10000
Cores                         Utilization: 10% (Total: 10 Used: 1 Free: 9)
Memory                        Utilization: 1% (Total: 19,031 MB Used: 128 MB Free: 18,903 MB)
Number of live executors      1
Applications                  Active: 1 Total: 1
```
### command doesn't need endpoint
```
$ ./drove.py config get-clusters
CURRENT    NAME                 ENDPOINT                                           AUTH   INSECURE
-----------------------------------------------------------------------------------------------
           dev                  http://localhost:10000                             yes    no      
           docker               http://localhost:4000                              yes    no      
           oss                  http://drove.local:7000                            yes    no      
           vm                   http://192.168.56.10:10000                         yes    no      
```