### PR TITLE
Added support for generating shell completion file

### DIFF
--- a/drove.py
+++ b/drove.py
@@ -18,6 +18,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--username", "-u", help="Drove cluster username")
     parser.add_argument("--password", "-p", help="Drove cluster password")
     parser.add_argument("--debug", "-d", help="Print details of errors", default=False, action="store_true")
+    parser.add_argument("--print-completion", choices=["bash", "zsh", "tcsh"], help="Print shell completion script for the given shell")
     return parser
 
 def get_parser():
@@ -25,7 +26,7 @@ def get_parser():
     client = None
     client = drovecli.DroveCli(parser)
     return client.parser
- 
+
 
 def run():
     parser = build_parser()

--- a/drovecli.py
+++ b/drovecli.py
@@ -2,7 +2,7 @@ import argparse
 import droveclient
 from plugins import DrovePlugin
 from types import SimpleNamespace
-
+import shtab
 
 
 class DroveCli:
@@ -23,6 +23,10 @@ class DroveCli:
     def run(self):
         args = self.parser.parse_args()
         self.debug = args.debug
+
+        if args.print_completion:
+            print(shtab.complete(self.parser, shell=args.print_completion))
+            exit(0)
 
         # Load plugins
         if args.debug:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Requests==2.32.5
 tabulate==0.9.0
 tenacity==9.1.2
 urllib3==2.5.0
+shtab

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Requests==2.32.5
 tabulate==0.9.0
 tenacity==9.1.2
 urllib3==2.5.0
-shtab
+shtab==1.8.0


### PR DESCRIPTION
To generate completion:

```shell
drove -print-completion bash > drove.bash.completions
source drove.bash.completions
```

- Supports completions at all levels
- supports bash, zsh and tcsh
- Adds dependency on `shtab` .. :cry: 

