### PR TITLE
fix: add missing --app argument to executor tasks subparser

### DIFF
--- a/plugins/executors.py
+++ b/plugins/executors.py
@@ -34,6 +34,7 @@ class Executors(plugins.DrovePlugin):
 
         sub_parser = commands.add_parser("tasks", help="Show tasks running on this executor")
         sub_parser.add_argument("executor_id", metavar="executor-id", help="Executor id for which info is to be shown")
+        sub_parser.add_argument("--app", "-a", help="Show tasks only for the given source app", type=str)
         sub_parser.add_argument("--sort", "-s", help="Sort output by column", type=int, choices=range(0, 6), default = 1)
         sub_parser.add_argument("--reverse", "-r", help="Sort in reverse order", action="store_true")
         sub_parser.set_defaults(func=self.show_tasks)

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -123,7 +123,20 @@ _EXECUTOR_INFO_SEED = {
     },
     # Running instances (empty by default; populated during test lifecycle)
     "instances": [],
-    "tasks": [],
+    "tasks": [
+        {
+            "instanceId": "TI-mock-task-001",
+            "sourceAppName": "TEST_APP",
+            "taskId": "T0012",
+            "state": "RUNNING",
+            "resources": [
+                {"type": "CPU", "cores": {"0": [0, 1]}},
+                {"type": "MEMORY", "memoryInMB": {"0": 256}},
+            ],
+            "created": 1700000020000,
+            "updated": 1700000020000,
+        },
+    ],
     "serviceInstances": [],
 }
 

--- a/tests/test_offline_executor.py
+++ b/tests/test_offline_executor.py
@@ -76,3 +76,37 @@ class TestOfflineDescribeExecutor:
         out = drove_ok("describe", "executor", offline_executor_id, "--json")
         data = json.loads(out)
         assert isinstance(data, dict)
+
+
+class TestOfflineExecutorTasks:
+    """Tests for `drove executor tasks` — verifies the --app filter works.
+
+    The mock executor seed data includes a task with sourceAppName='TEST_APP'.
+    Before the fix, running `drove executor tasks <id>` with any tasks present
+    would crash with ``AttributeError: 'Namespace' object has no attribute 'app'``
+    because the ``--app`` argument was missing from the subparser definition.
+    """
+
+    def test_executor_tasks_shows_task_data(self, offline_executor_id):
+        """Tasks output should contain the seeded task information."""
+        from conftest import drove_ok
+        out = drove_ok("executor", "tasks", offline_executor_id)
+        assert "TEST_APP" in out, (
+            f"Expected 'TEST_APP' in tasks output but got:\n{out}"
+        )
+
+    def test_executor_tasks_app_filter_shows_match(self, offline_executor_id):
+        """The --app flag should show tasks matching the given source app."""
+        from conftest import drove_ok
+        out = drove_ok("executor", "tasks", offline_executor_id, "--app", "TEST_APP")
+        assert "TEST_APP" in out, (
+            f"Expected 'TEST_APP' in filtered output but got:\n{out}"
+        )
+
+    def test_executor_tasks_app_filter_excludes_nonmatch(self, offline_executor_id):
+        """The --app flag should exclude tasks from other apps."""
+        from conftest import drove_ok
+        out = drove_ok("executor", "tasks", offline_executor_id, "--app", "NONEXISTENT_APP")
+        assert "TEST_APP" not in out, (
+            f"Expected 'TEST_APP' to be filtered out but got:\n{out}"
+        )


### PR DESCRIPTION
## Problem

`drove executor tasks <executor-id>` crashes with `AttributeError: 'Namespace' object has no attribute 'app'` when any tasks exist on the executor.

**Root cause:** `plugins/executors.py` line 125 references `options.app` to filter tasks by source app, but the `tasks` subparser (lines 35-39) never defines the `--app` argument. The `drove tasks list` command in `plugins/tasks.py` correctly defines this argument.

The existing test (`test_executor_tasks_succeeds`) didn't catch this because the mock server's executor had an empty tasks list, so the buggy code path was never reached.

## Fix

- Added `--app` / `-a` argument to the `executor tasks` subparser, matching the pattern in `plugins/tasks.py`
- Added task seed data to the mock executor in `tests/mock_server.py`
- Added 3 new offline tests that verify the fix

## Testing

All offline tests pass (`pytest -m offline`):
- `test_executor_tasks_shows_task_data` - verifies tasks are displayed when present
- `test_executor_tasks_app_filter_shows_match` - verifies `--app` shows matching tasks
- `test_executor_tasks_app_filter_excludes_nonmatch` - verifies `--app` hides non-matching tasks
